### PR TITLE
Fix after change json models on backend

### DIFF
--- a/Example/MagellanExample.xcodeproj/project.pbxproj
+++ b/Example/MagellanExample.xcodeproj/project.pbxproj
@@ -692,8 +692,10 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = YLWWUD25VZ;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = MagellanExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -714,8 +716,9 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = YLWWUD25VZ;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = MagellanExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/MagellanExampleTests/AutoGenerated/AutoMockable.generated.swift
+++ b/Example/MagellanExampleTests/AutoGenerated/AutoMockable.generated.swift
@@ -1,6 +1,5 @@
-// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.4.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
 
@@ -529,7 +528,7 @@ class MapPresenterProtocolMock: MapPresenterProtocol {
     var loadPlacesTopLeftBottomRightZoomReceivedArguments: (topLeft: Coordinates, bottomRight: Coordinates, zoom: Int)?
     var loadPlacesTopLeftBottomRightZoomClosure: ((Coordinates, Coordinates, Int) -> Void)?
 
-    func loadPlaces(topLeft:Coordinates, bottomRight: Coordinates, zoom: Int) {
+    func loadPlaces(topLeft: Coordinates, bottomRight: Coordinates, zoom: Int) {
         loadPlacesTopLeftBottomRightZoomCallsCount += 1
         loadPlacesTopLeftBottomRightZoomReceivedArguments = (topLeft: topLeft, bottomRight: bottomRight, zoom: zoom)
         loadPlacesTopLeftBottomRightZoomClosure?(topLeft, bottomRight, zoom)

--- a/Example/MagellanExampleTests/Modules/CategoriesFilterPresenterTests.swift
+++ b/Example/MagellanExampleTests/Modules/CategoriesFilterPresenterTests.swift
@@ -18,9 +18,9 @@ class CategoriesFilterPresenterTests: XCTestCase {
     var categories: [PlaceCategory] {
         
         return [
-            PlaceCategory(id: 0, name: "zero", khmerName: nil),
-            PlaceCategory(id: 1, name: "first", khmerName: nil),
-            PlaceCategory(id: 2, name: "second", khmerName: nil),
+            PlaceCategory(id: 0, name: "zero", names: nil, khmerName: nil),
+            PlaceCategory(id: 1, name: "first", names: nil, khmerName: nil),
+            PlaceCategory(id: 2, name: "second", names: nil, khmerName: nil),
         ]
     }
     

--- a/Example/MagellanExampleTests/Modules/LocationDetailPresenterTests.swift
+++ b/Example/MagellanExampleTests/Modules/LocationDetailPresenterTests.swift
@@ -16,6 +16,7 @@ final class LocationDetailPresenterTests: XCTestCase {
         return PlaceInfo(id: "1",
                         name: "name",
                         type: "type",
+                        types: nil,
                         khmerType: nil,
                         coordinates: Coordinates(lat: 1, lon: 1),
                         address: "addr",

--- a/Example/MagellanExampleTests/Modules/MapListPresenterTests.swift
+++ b/Example/MagellanExampleTests/Modules/MapListPresenterTests.swift
@@ -18,17 +18,17 @@ final class MapListPresenterTests: XCTestCase {
     
     var categoties: [Magellan.PlaceCategory] {
         return [
-            Magellan.PlaceCategory(id: 1, name: "1", khmerName: nil),
-            Magellan.PlaceCategory(id: 2, name: "2", khmerName: nil),
-            Magellan.PlaceCategory(id: 3, name: "3", khmerName: nil),
-            Magellan.PlaceCategory(id: 4, name: "4", khmerName: nil),
+            Magellan.PlaceCategory(id: 1, name: "1", names: nil, khmerName: nil),
+            Magellan.PlaceCategory(id: 2, name: "2", names: nil, khmerName: nil),
+            Magellan.PlaceCategory(id: 3, name: "3", names: nil, khmerName: nil),
+            Magellan.PlaceCategory(id: 4, name: "4", names: nil, khmerName: nil),
         ]
     }
     
     var places: [Place] {
         return [
-            Place(id: "1", name: "first", type: "one", khmerType: nil, coordinates: Coordinates(lat: 1, lon: 1)),
-            Place(id: "2", name: "second", type: "one", khmerType: nil, coordinates: Coordinates(lat: 2, lon: 2))
+            Place(id: "1", name: "first", type: "one", types: nil, khmerType: nil, coordinates: Coordinates(lat: 1, lon: 1)),
+            Place(id: "2", name: "second", type: "one", types: nil, khmerType: nil, coordinates: Coordinates(lat: 2, lon: 2))
         ]
     }
     
@@ -36,6 +36,7 @@ final class MapListPresenterTests: XCTestCase {
         return PlaceInfo(id: "1",
         name: "name",
         type: "type",
+        types: nil,
         khmerType: nil,
         coordinates: Coordinates(lat: 1, lon: 1),
         address: "addr",

--- a/Example/MagellanExampleTests/Modules/MapPresenterTests.swift
+++ b/Example/MagellanExampleTests/Modules/MapPresenterTests.swift
@@ -22,17 +22,17 @@ final class MapPresenterTests: XCTestCase {
     
     var categoties: [Magellan.PlaceCategory] {
         return [
-            Magellan.PlaceCategory(id: 1, name: "1", khmerName: nil),
-            Magellan.PlaceCategory(id: 2, name: "2", khmerName: nil),
-            Magellan.PlaceCategory(id: 3, name: "3", khmerName: nil),
-            Magellan.PlaceCategory(id: 4, name: "4", khmerName: nil),
+            Magellan.PlaceCategory(id: 1, name: "1", names: nil, khmerName: nil),
+            Magellan.PlaceCategory(id: 2, name: "2", names: nil, khmerName: nil),
+            Magellan.PlaceCategory(id: 3, name: "3", names: nil, khmerName: nil),
+            Magellan.PlaceCategory(id: 4, name: "4", names: nil, khmerName: nil),
         ]
     }
     
     var places: [Place] {
         return [
-            Place(id: "1", name: "first", type: "one", khmerType: nil, coordinates: Coordinates(lat: 1, lon: 1)),
-            Place(id: "2", name: "second", type: "one", khmerType: nil, coordinates: Coordinates(lat: 2, lon: 2))
+            Place(id: "1", name: "first", type: "one", types: nil, khmerType: nil, coordinates: Coordinates(lat: 1, lon: 1)),
+            Place(id: "2", name: "second", type: "one", types: nil, khmerType: nil, coordinates: Coordinates(lat: 2, lon: 2))
         ]
     }
     
@@ -40,6 +40,7 @@ final class MapPresenterTests: XCTestCase {
         return PlaceInfo(id: "1",
                 name: "name",
                 type: "type",
+                types: nil,
                 khmerType: nil,
                 coordinates: Coordinates(lat: 1, lon: 1),
                 address: "addr",

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -21,5 +21,13 @@ end
 post_install do |installer|
   installer.pods_project.build_configuration_list.build_configurations.each do |configuration|
     configuration.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'
+    
+      installer.pods_project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings['SWIFT_VERSION'] = '5.0'
+          config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+          config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = "11.0"
+        end
+      end
   end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -88,7 +88,7 @@ PODS:
     - SoraFoundation/DateProcessing (~> 0.7.0)
     - SoraFoundation/Localization (~> 0.7.0)
     - SoraFoundation/NotificationHandlers (~> 0.7.0)
-    - SoraUI (~> 1.8.7)
+    - SoraUI
     - SVProgressHUD
   - nanopb (1.30905.0):
     - nanopb/decode (= 1.30905.0)
@@ -187,8 +187,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Crashlytics: 540b7e5f5da5a042647227a5e3ac51d85eed06df
-  Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
+  Crashlytics: 9220f5bc89e7a618df411b4f639389dbfb0e03d2
+  Fabric: ea977e3cd9c20425516d3dafd3bf8c941c51223f
   Firebase: 210f41ca352067d83b1ba4fd2e7fb49a0c017397
   FirebaseAnalytics: a299a86ef70fcc6aa011418bc65a7e101fb9636c
   FirebaseCore: 9a41e2de78fef10f63cee30ab10e2945266bc1fc
@@ -200,7 +200,7 @@ SPEC CHECKSUMS:
   GoogleMaps: 4b5346bddfe6911bb89155d43c903020170523ac
   GoogleUtilities: 7f2f5a07f888cdb145101d6042bc4422f57e70b3
   libPhoneNumber-iOS: 0a32a9525cf8744fe02c5206eb30d571e38f7d75
-  Magellan: 5d910f07076b5ccf54b5b47ba97730e66d54687e
+  Magellan: e24062ee1d2611e1173008747a3b435814515e6e
   nanopb: c43f40fadfe79e8b8db116583945847910cbabc9
   OHHTTPStubs: cb29d2a9d09a828ecb93349a2b0c64f99e0db89f
   PromisesObjC: b14b1c6b68e306650688599de8a45e49fae81151
@@ -211,6 +211,6 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 7a0227733d786395817373b2d0ca799fd0093ff3
 
-PODFILE CHECKSUM: 9785b69787bd6286dff9c7dc18fb4891e7a32d9d
+PODFILE CHECKSUM: 34a0cc2bb4a6114d3d3e998fd5246befe5615d20
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1

--- a/Magellan.podspec
+++ b/Magellan.podspec
@@ -13,8 +13,10 @@ Library allow fast integration of Soramitsu Places.
   s.author           = { 'Andrei Marin' => 'marin@soramitsu.co.jp', 'Ruslan Rezin' => 'rezin@soramitsu.co.jp', 'Iskander Foatov' => 'foatov@soramitsu.co.jp' }
   s.source           = { :git => 'https://github.com/soramitsu/Magellan-iOS.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   s.static_framework = true
   s.source_files = 'Magellan/Classes/**/*.swift'
   s.ios.resource_bundle = { 'Magellan' => ['Magellan/Assets/*.xcassets' , 'Magellan/Assets/Lang/**/*'] }

--- a/Magellan/Classes/Common/PlaceInfoViewModel.swift
+++ b/Magellan/Classes/Common/PlaceInfoViewModel.swift
@@ -21,11 +21,21 @@ struct PlaceInfoViewModel {
     }
     
     var type: String {
-        return place.type
+        if let type = place.type {
+            return type
+        } else if let types = place.types {
+            return types.eng
+        }
+        return ""
     }
     
     var khmerType: String? {
-        return place.khmerType
+        if let khmerType = place.khmerType {
+            return khmerType
+        } else if let types = place.types {
+            return types.khm
+        }
+        return ""
     }
     
     var coordinates: Coordinates {

--- a/Magellan/Classes/Models/Place.swift
+++ b/Magellan/Classes/Models/Place.swift
@@ -10,7 +10,7 @@ import Foundation
 struct Place {
     let id: String
     let name: String
-    let type: String
+    let type: String?
     let types: Types?
     let khmerType: String?
     let coordinates: Coordinates

--- a/Magellan/Classes/Models/Place.swift
+++ b/Magellan/Classes/Models/Place.swift
@@ -11,8 +11,23 @@ struct Place {
     let id: String
     let name: String
     let type: String
+    let types: Types?
     let khmerType: String?
     let coordinates: Coordinates
+}
+
+struct Types: Codable, Equatable {
+    let eng: String
+    let khm: String
+    let engLowerCase: String
+    let lhmLowerCase: String
+
+    enum CodingKeys: String, CodingKey {
+        case eng = "ENG"
+        case khm = "KHM"
+        case engLowerCase = "ENGLowerCase"
+        case lhmLowerCase = "KHMLowerCase"
+    }
 }
 
 extension Place: Coordinated { }

--- a/Magellan/Classes/Models/PlaceCategory.swift
+++ b/Magellan/Classes/Models/PlaceCategory.swift
@@ -9,8 +9,19 @@ import Foundation
 
 struct PlaceCategory {
     let id: UInt64
-    let name: String
+    let name: String?
+    let names: Names?
     let khmerName: String?
+}
+
+struct Names: Codable, Hashable {
+    let eng: String
+    let khm: String
+
+    enum CodingKeys: String, CodingKey {
+        case eng = "ENG"
+        case khm = "KHM"
+    }
 }
 
 extension PlaceCategory: Equatable {

--- a/Magellan/Classes/Models/PlaceInfo.swift
+++ b/Magellan/Classes/Models/PlaceInfo.swift
@@ -72,7 +72,8 @@ struct PlaceInfo: Coordinated {
     
     let id: String
     let name: String
-    let type: String
+    let type: String?
+    let types: Types?
     let khmerType: String?
     let coordinates: Coordinates
     let address: String

--- a/Magellan/Classes/Modules/CategoriesFilter/CategoryFilterViewModel.swift
+++ b/Magellan/Classes/Modules/CategoriesFilter/CategoryFilterViewModel.swift
@@ -15,10 +15,18 @@ struct CategoryFilterViewModel {
     var isSelected: Bool
     
     var name: String {
-        if locale.isKm {
-            return category.khmerName ?? category.name
+        if let names = category.names {
+            if locale.isKm {
+                return names.khm
+            }
+            return names.eng
+        } else if let name = category.name {
+            if locale.isKm {
+                return category.khmerName ?? name
+            }
+            return name
         }
-        return category.name
+        return ""
     }
     
     var count: String {
@@ -26,7 +34,7 @@ struct CategoryFilterViewModel {
     }
     
     var image: UIImage {
-        guard let image = UIImage(named: "filter_\(category.name.lowercased())", in: Bundle.frameworkBundle, compatibleWith: nil) else {
+        guard let image = UIImage(named: "filter_\(name.lowercased())", in: Bundle.frameworkBundle, compatibleWith: nil) else {
             return UIImage(named: "filter_other", in: Bundle.frameworkBundle, compatibleWith: nil)!
         }
         

--- a/Magellan/Classes/Modules/MapList/PlaceViewModel.swift
+++ b/Magellan/Classes/Modules/MapList/PlaceViewModel.swift
@@ -25,8 +25,13 @@ class PlaceViewModel: NSObject, Coordinated {
     
     var category: String {
         guard locale.isKm,
-            let khmerType = place.khmerType else {
-                return place.type
+              let khmerType = place.khmerType else {
+            if let type = place.type {
+                return type
+            } else if let types = place.types {
+                return locale.isKm ? types.khm : types.eng
+            }
+            return ""
         }
         return khmerType
     }


### PR DESCRIPTION
Fixed json models after change on backend for types and names fields

endpoints (with old models)
https://pgateway1.s1.tst.bakong.soramitsu.co.jp/paymentservice/api/v1/merchants/types
https://pgateway1.s1.tst.bakong.soramitsu.co.jp/paymentservice/api/v1/merchants

endpoints (with new models)
https://pgateway1.s1.dev.bakong.soramitsu.co.jp/paymentservice/api/v1/merchants
https://pgateway1.s1.dev.bakong.soramitsu.co.jp/paymentservice/api/v1/merchants/types

changes:
"names": {
                "ENG": "type",
                "KHM": "type"
         },

"types": {
            "KHM": "New type 1",
            "ENGLowerCase": "new type 1",
            "KHMLowerCase": "new type 1",
            "ENG": "New type 1"
        },